### PR TITLE
[サーバーサイド]RECOの最近の投稿をリスト形式で表示するサイト

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem 'sinatra'
+gem 'thin'
+gem 'sinatra-contrib'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,39 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    backports (2.8.2)
+    daemons (1.2.6)
+    eventmachine (1.2.7)
+    multi_json (1.13.1)
+    mustermann (1.0.2)
+    rack (2.0.5)
+    rack-protection (2.0.2)
+      rack
+    sinatra (2.0.2)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.2)
+      tilt (~> 2.0)
+    sinatra-contrib (2.0.2)
+      backports (~> 2.8.2)
+      multi_json
+      mustermann (~> 1.0)
+      rack-protection (= 2.0.2)
+      sinatra (= 2.0.2)
+      tilt (>= 1.3, < 3)
+    thin (1.7.2)
+      daemons (~> 1.0, >= 1.0.9)
+      eventmachine (~> 1.0, >= 1.0.4)
+      rack (>= 1, < 3)
+    tilt (2.0.8)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sinatra
+  sinatra-contrib
+  thin
+
+BUNDLED WITH
+   1.16.1

--- a/RssItem.rb
+++ b/RssItem.rb
@@ -1,0 +1,18 @@
+require 'rss'
+
+class RssItem
+  attr_accessor :posts
+
+  def initialize(url)
+    @posts = []
+    rss = RSS::Parser.parse(url)
+    rss.items.each do |item|
+      @posts << {
+        title: item.title,
+        link: item.link,
+        date: item.pubDate.strftime("%a, %d %b %Y"),
+        description: item.description
+      }
+    end
+  end
+end

--- a/app.rb
+++ b/app.rb
@@ -1,0 +1,11 @@
+require File.dirname(__FILE__) + "/RssItem"
+require 'sinatra'
+require 'sinatra/reloader'
+
+url = "http://reco-photo.com/feed"
+reco = RssItem.new(url)
+
+get '/' do
+  @posts = reco.posts
+  erb :index
+end

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,44 @@
+body{
+  font-family: Open Sans,"Noto Sans Japanese", sans-serif;
+}
+
+.header{
+  text-align: center;
+  margin: 30px;
+}
+
+.header h1{
+  font-size: 80px;
+  margin-bottom: 10px;
+}
+
+.header h2{
+  font-size: 40px;
+  font-weight: 300;
+  margin-top: 0;
+}
+
+.post{
+  width: 850px;
+  margin: 50px auto;
+  font-weight: 200;
+}
+
+a{
+  text-decoration: none;
+  color: black;
+}
+
+a:hover{
+  color: #dbdbdb;
+}
+
+.title{
+  font-size: 30px;
+}
+
+footer{
+  text-align: center;
+  color: #c6c4c4;
+  margin: 20px;
+}

--- a/views/index.erb
+++ b/views/index.erb
@@ -1,0 +1,24 @@
+<html>
+<head>
+  <title>eureka intern</title>
+  <link rel="stylesheet" href="/style.css" />
+  <link href="https://fonts.googleapis.com/earlyaccess/notosansjapanese.css" rel="stylesheet" />
+  <link rel="stylesheet"
+  href="http://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700">
+
+</head>
+<body>
+  <div class="header">
+    <h1>RECO</h1>
+    <h2>recently posts<h2>
+  </div>
+  <% @posts.each do |post| %>
+    <div class="post">
+      <a class = "title" href = <%= post[:link] %>><%= post[:title] %></a>
+      <p class="description"><%= post[:description] %></p>
+      <p class="date"><%= post[:date] %></p>
+    </div>
+  <% end %>
+  <footer>©2018 eureka-summer-internship</footer>
+  </body>
+</html>


### PR DESCRIPTION
#仕様説明
RECO[http://reco-photo.com/](url)とは写真をもっと楽しくするメディアです。
写真が好きなので、RECOの最近の投稿をリスト形式で表示するサイトを作りました。
##機能の説明
- 投稿ごとにタイトル、投稿の冒頭部分、投稿日を表示
- タイトルをクリックするとRECOの投稿ページに遷移
##スクリーンショット
![Uploading スクリーンショット 2018-06-08 5.56.25.png…]()

#環境構築マニュアル
＊このブランチをfetchして、チェックアウトまで済ませたものとする
##gemのインストール

```
bundle install
```
##アプリケーションの実行

```
ruby app.rb
```

ブラウザで`localhost:4567`にアクセス

#使用言語、ライブラリ
- ruby2.4
- sinatra
- sinatra-contrib
- thin
- html
- css
##選定理由
普段使用しているのでrubyを用いた。sinatraの選定理由はこのような小規模なwebサービスであればsinatraでシンプルに開発できると考えたから。また、これまでwebフレームワークはRailsしか使ったことがなく、勉強してみたかった。
webサーバーにthinを使った理由は特にない。

#こだわりポイント
- 初めてのsinatraでスッキリ開発
- シンプルで見やすいデザイン
- 特に意味はないcopyright
- まさかの1コミット
